### PR TITLE
update 'update pip'

### DIFF
--- a/docker_user_guide.md
+++ b/docker_user_guide.md
@@ -110,7 +110,7 @@ root@[고유번호]:~/PyTorch#
 필수 패키지를 설치해줍니다.
 
 ```
-root@[고유번호]:~/PyTorch# conda update -y pip
+root@[고유번호]:~/PyTorch# pip install --upgrade pip
 root@[고유번호]:~/PyTorch# pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
기존에 `conda update -y pip`  명령어로 pip update를 진행하게 되면 conda 환경변수를 잃게 되는 현상이 나타나게 됩니다.
`pip install --upgrade pip` 명령어로 pip update를 진행하는 것이 좋을 것 같습니다.