### PR TITLE
Lab-11-5코드실행중 GPU 환경에서 evalueate 실행과정에서 발생하는 오류 해결

### DIFF
--- a/lab-11_5_seq2seq.ipynb
+++ b/lab-11_5_seq2seq.ipynb
@@ -253,7 +253,7 @@
     "        for ei in range(source_length):\n",
     "            _, encoder_hidden = encoder(source_tensor[ei], encoder_hidden)\n",
     "\n",
-    "        decoder_input = torch.Tensor([[SOS_token]], device=device).long()\n",
+    "        decoder_input = torch.Tensor([[SOS_token]]).long().to(device)\n",
     "        decoder_hidden = encoder_hidden\n",
     "        decoded_words = []\n",
     "\n",


### PR DESCRIPTION
RuntimeError: legacy constructor for device type: cpu was passed device type: cuda, but device type must be: cpu
발생하는 오류를 해결